### PR TITLE
Add support for sourcemaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,22 @@ You can configure this plugin in `_config.yml`.
 ``` yaml
 stylus:
   compress: false
+  sourcemaps:
+    comment: true
+    inline: true
+    sourceRoot: ''
+    basePath: .
 ```
 
-- **compress** - Compress generated CSS
+- **Stylus**:
+  - **compress** - Compress generated CSS (default: `false`)
+
+
+- **Sourcemaps**
+  - **comment** - Adds a comment with the `sourceMappingURL` to the generated CSS (default: `true`)
+  - **inline** - Inlines the sourcemap with full source text in base64 format (default: `false`)
+  - **sourceRoot** - `sourceRoot` property of the generated sourcemap
+  - **basePath** - Base path from which sourcemap and all sources are relative (default: `.`)
 
 [Stylus]: http://learnboost.github.io/stylus/
 [nib]: http://visionmedia.github.io/nib/

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -40,6 +40,7 @@ module.exports = function(data, options, callback){
     .use(nib())
     .use(defineConfig)
     .set('filename', data.path)
+    .set('sourcemap', config.sourcemaps)
     .set('compress', config.compress)
     .set('include css', true)
     .render(callback);


### PR DESCRIPTION
Fixes #2.

Adds support for sourcemaps and sourcemap options present in Stylus.

Also adds documentation on how to configure `_config.yml` to enable sourcemaps feature.

(Don't really know what should be the default value for `sourceRoot`. All tested values seem to work.)