### PR TITLE
Adds configurable plugin support Fixes #12

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ stylus:
     inline: true
     sourceRoot: ''
     basePath: .
+  plugins:
+    - plugin-module-name
 ```
 
 - **Stylus**:
@@ -37,6 +39,9 @@ stylus:
   - **inline** - Inlines the sourcemap with full source text in base64 format (default: `false`)
   - **sourceRoot** - `sourceRoot` property of the generated sourcemap
   - **basePath** - Base path from which sourcemap and all sources are relative (default: `.`)
+  
+- ** Plugins
+  - **moduleName** - name of stylus plugin to include into `use` of stylus configuration
 
 [Stylus]: http://stylus-lang.com/
 [nib]: http://stylus.github.io/nib/

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -1,6 +1,38 @@
 'use strict';
 
+// TODO: There is no reason to hard code nib in here now.
+//       But keeping for backward compatibility.
+
 var stylus, nib;
+
+module.exports = function(data, options, callback) {
+  // Lazy require
+  if (!stylus) {
+    stylus = require('stylus');
+  }
+
+  var config = this.config.stylus || {};
+  var self = this;
+  var plugins = ['nib'].concat(config.plugins || []);
+
+  function defineConfig(style) {
+    style.define('hexo-config', function(data) {
+      return getProperty(self.theme.config, data.val);
+    });
+  }
+
+  var stylusConfig = stylus(data.text);
+
+  applyPlugins(stylusConfig, plugins);
+
+  stylusConfig
+    .use(defineConfig)
+    .set('filename', data.path)
+    .set('sourcemap', config.sourcemaps)
+    .set('compress', config.compress)
+    .set('include css', true)
+    .render(callback);
+};
 
 function getProperty(obj, name) {
   name = name.replace(/\[(\w+)\]/g, '.$1').replace(/^\./, '');
@@ -27,28 +59,10 @@ function getProperty(obj, name) {
   return result;
 }
 
-module.exports = function(data, options, callback) {
-  // Lazy require
-  if (!stylus) {
-    stylus = require('stylus');
-    nib = require('nib');
-  }
-
-  var config = this.config.stylus || {};
-  var self = this;
-
-  function defineConfig(style) {
-    style.define('hexo-config', function(data) {
-      return getProperty(self.theme.config, data.val);
-    });
-  }
-
-  stylus(data.text)
-    .use(nib())
-    .use(defineConfig)
-    .set('filename', data.path)
-    .set('sourcemap', config.sourcemaps)
-    .set('compress', config.compress)
-    .set('include css', true)
-    .render(callback);
-};
+function applyPlugins(stylusConfig, plugins) {
+  plugins.forEach(function(plugin) {
+    var moduleName = plugin.trim();
+    var factoryFn = require(moduleName);
+    stylusConfig.use(factoryFn());
+  });
+}

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -3,7 +3,7 @@
 // TODO: There is no reason to hard code nib in here now.
 //       But keeping for backward compatibility.
 
-var stylus, nib;
+var stylus;
 
 module.exports = function(data, options, callback) {
   // Lazy require


### PR DESCRIPTION
Added simple way to add configurable plugin support to hexo-renderer stylus. You just add the name of the module and it will apply it. 