### PR TITLE
feat: configurable plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![NPM version](https://badge.fury.io/js/hexo-renderer-stylus.svg)](https://www.npmjs.com/package/hexo-renderer-stylus)
 [![Coverage Status](https://img.shields.io/coveralls/hexojs/hexo-renderer-stylus.svg)](https://coveralls.io/r/hexojs/hexo-renderer-stylus?branch=master)
 
-Add support for [Stylus] with [nib].
+Add support for [Stylus] with [nib] and other plugins.
 
 ## Install
 
@@ -28,17 +28,16 @@ stylus:
     inline: true
     sourceRoot: ''
     basePath: .
+  plugins: 'nib'
 ```
 
-- **Stylus**:
-  - **compress** - Compress generated CSS (default: `false`)
-
-
-- **Sourcemaps**
+- **compress** - Compress generated CSS (default: `false`)
+- **sourcemaps**
   - **comment** - Adds a comment with the `sourceMappingURL` to the generated CSS (default: `true`)
   - **inline** - Inlines the sourcemap with full source text in base64 format (default: `false`)
   - **sourceRoot** - `sourceRoot` property of the generated sourcemap
   - **basePath** - Base path from which sourcemap and all sources are relative (default: `.`)
+- **plugins** - Stylus plugin(s) (default: `nib`)
 
 [Stylus]: http://stylus-lang.com/
 [nib]: http://stylus.github.io/nib/

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const stylus = require('stylus');
-const nib = require('nib');
 
 function getProperty(obj, name) {
   name = name.replace(/\[(\w+)\]/g, '.$1').replace(/^\./, '');
@@ -28,18 +27,29 @@ function getProperty(obj, name) {
   return result;
 }
 
+function applyPlugins(stylusConfig, plugins) {
+  plugins.forEach(plugin => {
+    const factoryFn = require(plugin.trim());
+    stylusConfig.use(factoryFn());
+  });
+}
+
 module.exports = function(data, options, callback) {
   const config = this.config.stylus || {};
   const self = this;
+  const plugins = ['nib'].concat(config.plugins || []);
 
   function defineConfig(style) {
-    style.define('hexo-config', function(data) {
+    style.define('hexo-config', data => {
       return getProperty(self.theme.config, data.val);
     });
   }
 
-  stylus(data.text)
-    .use(nib())
+  const stylusConfig = stylus(data.text);
+
+  applyPlugins(stylusConfig, plugins);
+
+  stylusConfig
     .use(defineConfig)
     .set('filename', data.path)
     .set('sourcemap', config.sourcemaps)


### PR DESCRIPTION
Based on https://github.com/hexojs/hexo-renderer-stylus/pull/29 @jamelt, with ES6 syntax.
Fixes #12 , Closes #29 

### How to test
`$ git clone --depth 1 https://github.com/hexojs/hexo-theme-landscape themes/landscape`
``` diff
config.yml
-theme: current-theme
+theme: landscape
```

Install this PR branch and [Axis](https://axis.netlify.com/) (a Stylus plugin),
``` diff
package.json
-  "hexo-renderer-stylus": "^1.0.0"
+  "hexo-renderer-stylus: "curbengh/hexo-renderer-stylus#plugins",
+  "axis": "^1.0.0"
```

``` diff
_config.yml
+stylus:
+  plugins: 'axis'
```

``` diff
themes/landscape/source/css/style.styl
+.selector
+  glossy-button()
```

`$ hexo clean && hexo g`

public/css/style.css should have
``` css
.selector {
  font-size: 13px;
  padding: 10px 22px;
  border-radius: 3px;
  background: #0084f6;
  ...
}
```