### PR TITLE
Change the behavior of plugins configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ stylus:
   - **inline** - Inlines the sourcemap with full source text in base64 format (default: `false`)
   - **sourceRoot** - `sourceRoot` property of the generated sourcemap
   - **basePath** - Base path from which sourcemap and all sources are relative (default: `.`)
-- **plugins** - Stylus plugin(s) (default: `nib`)
+- **plugins** - Stylus plugin(s) (default: `nib`, set `''` to disable all plugins)
 
 ## Setting Stylus variables
 

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -37,7 +37,7 @@ function applyPlugins(stylusConfig, plugins) {
 function stylusFn(data, options, callback) {
   const config = this.config.stylus || {};
   const self = this;
-  const plugins = ['nib'].concat(config.plugins || []);
+  const plugins = config.plugins ? ['nib'].concat(config.plugins) : (config.plugins === '' ? [] : ['nib']);
 
   function defineConfig(style) {
     style.define('hexo-config', data => {


### PR DESCRIPTION
I have viewed https://github.com/hexojs/hexo/issues/4619#issuecomment-766592787
So I know the nib's repo use stylus v0.54.8 but it haven't been published.
To remove the annoying warnings, I think users could disable nib in this renderer by using configuration like this if they don't need it :
``` yaml
stylus:
  plugins: ''
```
can it be applied to this renderer plugin?