### PR TITLE
fix:hexo-config() return '' causing error while should be 0 in some themes

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -13,7 +13,10 @@ function getProperty(obj, name) {
   let result = obj[key];
   const len = split.length;
 
-  if (!len) return result || '';
+  if (!len) {
+    if(result === 0) return result;
+    return result || '';
+  }
   if (typeof result !== 'object') return '';
 
   for (let i = 0; i < len; i++) {


### PR DESCRIPTION
`hexo-config(item)` will return empty string `''` if `item` is set as `0` in `_config.[theme].yml` due to `0 || ''` is `''` in /lib/renderer.js:line 16
And some themes need the value `0` or errors would occurr.(such as `hue` in [vivia](https://github.com/saicaca/hexo-theme-vivia))